### PR TITLE
Spell out POJO on first reference

### DIFF
--- a/src/guide/01-component-api.md
+++ b/src/guide/01-component-api.md
@@ -30,7 +30,7 @@ Every Svelte component instance has a small number of methods you can use to con
 
 ### component.set(data)
 
-This updates the component's state with the new values provided and causes the DOM to update. `data` must be a POJO. Any properties *not* included in `data` will remain as they were.
+This updates the component's state with the new values provided and causes the DOM to update. `data` must be a plain old JavaScript object (POJO). Any properties *not* included in `data` will remain as they were.
 
 ```js
 component.set({

--- a/src/guide/04-behaviour.md
+++ b/src/guide/04-behaviour.md
@@ -19,7 +19,7 @@ As well as scoped styles and a template, components can encapsulate *behaviours*
 
 ### Default data
 
-Often, it makes sense for a component to have default data. This should be expressed as a function that returns a plain old JavaScript object (POJO):
+Often, it makes sense for a component to have default data. This should be expressed as a function that returns a POJO:
 
 ```html
 <p>Count: {{count}}</p>


### PR DESCRIPTION
The acronym's definition comes in section 4. This changes it so that it is spelled out on first reference in section 2 and referred to as `POJO` in section 4.