### PR TITLE
Replace deprecated functions `onrender` and `onteardown`.

### DIFF
--- a/src/guide/04-behaviour.md
+++ b/src/guide/04-behaviour.md
@@ -77,7 +77,7 @@ Notice that all we need to do to tell Svelte that `hours`, `minutes` and `second
 
 ### Lifecycle hooks
 
-There are two 'hooks' provided by Svelte for adding control logic – `onrender` and `onteardown`:
+There are two 'hooks' provided by Svelte for adding control logic – `oncreate` and `ondestroy`:
 
 ```html
 <p>
@@ -87,13 +87,13 @@ There are two 'hooks' provided by Svelte for adding control logic – `onrender
 
 <script>
 	export default {
-		onrender () {
+		oncreate () {
 			this.interval = setInterval( () => {
 				this.set({ time: new Date() });
 			}, 1000 );
 		},
 
-		onteardown () {
+		ondestroy () {
 			clearInterval( this.interval );
 		},
 
@@ -131,13 +131,13 @@ Helpers are simple functions that are used in your template. In the example abov
 			leftPad
 		},
 
-		onrender () {
+		oncreate () {
 			this.interval = setInterval( () => {
 				this.set({ time: new Date() });
 			}, 1000 );
 		},
 
-		onteardown () {
+		ondestroy () {
 			clearInterval( this.interval );
 		},
 

--- a/src/guide/05-element-directives.md
+++ b/src/guide/05-element-directives.md
@@ -128,7 +128,7 @@ Refs are a convenient way to store a reference to particular DOM nodes or compon
 
 <script>
 	export default {
-		onrender () {
+		oncreate () {
 			const canvas = this.refs.canvas;
 			const ctx = canvas.getContext( '2d' );
 


### PR DESCRIPTION
Using the functions in the docs gives warnings like this:

```
(23:4) – 'onrender' has been deprecated in favour of 'oncreate', and will cause an error in Svelte 2.x
(28:4) – 'onteardown' has been deprecated in favour of 'ondestroy', and will cause an error in Svelte 2.x
```

So this brings the guide up to date.