### PR TITLE
Improve ultrawide layout

### DIFF
--- a/src/blog/index.html
+++ b/src/blog/index.html
@@ -21,16 +21,18 @@
 
 <body>
 	<header>
-		<span class="menu-link">Menu</span>
-		<a href='/' class='logo'>Svelte</a>
+		<section>
+			<span class="menu-link">Menu</span>
+			<a href='/' class='logo'>Svelte</a>
 
-		<ul class="navigation">
-			<li><a href='/guide'>Guide</a></li>
-			<li><a href='/repl'>REPL</a></li>
-			<li><a class='active' href='/blog'>Blog</a></li>
-			<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
-			<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
-		</ul>
+			<ul class="navigation">
+				<li><a href='/guide'>Guide</a></li>
+				<li><a href='/repl'>REPL</a></li>
+				<li><a class='active' href='/blog'>Blog</a></li>
+				<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
+				<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
+			</ul>
+		</section>
 	</header>
 
 	<main>

--- a/src/blog/post.html
+++ b/src/blog/post.html
@@ -21,16 +21,18 @@
 
 <body>
 	<header>
-		<span class="menu-link">Menu</span>
-		<a href='/' class='logo'>Svelte</a>
+		<section>
+			<span class="menu-link">Menu</span>
+			<a href='/' class='logo'>Svelte</a>
 
-		<ul>
-			<li><a href='/guide'>Guide</a></li>
-			<li><a href='/repl'>REPL</a></li>
-			<li><a class='active' href='/blog'>Blog</a></li>
-			<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
-			<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
-		</ul>
+			<ul>
+				<li><a href='/guide'>Guide</a></li>
+				<li><a href='/repl'>REPL</a></li>
+				<li><a class='active' href='/blog'>Blog</a></li>
+				<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
+				<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
+			</ul>
+		</section>
 	</header>
 
 	<main>

--- a/src/css/guide/content.css
+++ b/src/css/guide/content.css
@@ -141,3 +141,11 @@
 		padding: 2em 2em 2em 16em;
 	}
 }
+
+@media (min-width: 1024px) {
+	.content {
+		width: 1024px;
+		left: 50%;
+		transform: translateX(-50%);
+	}
+}

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -165,3 +165,12 @@ header {
 		}
 	}
 }
+
+@media (min-width: 1024px) {
+	header {
+		section {
+			width: 1024px;
+			margin: 0 auto;
+		}
+	}
+}

--- a/src/css/repl/index.css
+++ b/src/css/repl/index.css
@@ -8,6 +8,20 @@
 	height: calc(100vh - 7em);
 }
 
+@media (min-width: 1024px) {
+	header {
+		text-align: left;
+		
+		section {
+			width: 100%;
+		}
+
+		.navigation {			
+			left: 8em;
+		}
+	}
+}
+
 @keyframes pulse {
 	0%   { opacity: 1; transform: scale(1.5); }
 	50%  { opacity: 0; transform: scale(1); }

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -106,3 +106,18 @@
 		width: 36%;
 	}
 } 
+
+@media (min-width: 1024px) {
+	.sidebar {
+		position: fixed;
+		top: 4em;
+		width: 14em;
+		height: calc(100% - 4em);
+		z-index: 2;
+		border-bottom: none;
+
+		/* Center wih left + translateX technique */
+		left: calc(50% - 16em); 
+		transform: translateX(calc(-50% - 9em)); /* slightly more than half due to spacing */
+	}
+}

--- a/src/files/index.html
+++ b/src/files/index.html
@@ -20,16 +20,18 @@
 
 <body>
 	<header>
-		<span class="menu-link">Menu</span>
-		<a href='/' class='logo'>Svelte</a>
+		<section>
+			<span class="menu-link">Menu</span>
+			<a href='/' class='logo'>Svelte</a>
 
-		<ul class="navigation">
-			<li><a href='/guide'>Guide</a></li>
-			<li><a href='/repl'>REPL</a></li>
-			<li><a href='/blog'>Blog</a></li>
-			<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
-			<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
-		</ul>
+			<ul class="navigation">
+				<li><a href='/guide'>Guide</a></li>
+				<li><a href='/repl'>REPL</a></li>
+				<li><a href='/blog'>Blog</a></li>
+				<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
+				<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
+			</ul>
+		</section>
 	</header>
 
 	<main>

--- a/src/files/repl/index.html
+++ b/src/files/repl/index.html
@@ -23,16 +23,18 @@
 
 <body>
 	<header>
-		<span class="menu-link">Menu</span>
-		<a href='/' class='logo'>Svelte</a>
+		<section>
+			<span class="menu-link">Menu</span>
+			<a href='/' class='logo'>Svelte</a>
 
-		<ul class="navigation">
-			<li><a href='/guide'>Guide</a></li>
-			<li><a class='active' href='/repl'>REPL</a></li>
-			<li><a href='/blog'>Blog</a></li>
-			<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
-			<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
-		</ul>
+			<ul class="navigation">
+				<li><a href='/guide'>Guide</a></li>
+				<li><a class='active' href='/repl'>REPL</a></li>
+				<li><a href='/blog'>Blog</a></li>
+				<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
+				<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
+			</ul>
+		</section>
 	</header>
 
 	<main>

--- a/src/guide/index.html
+++ b/src/guide/index.html
@@ -24,16 +24,18 @@
 
 <body>
 	<header>
-		<span class="menu-link">Menu</span>
-		<a href='/' class='logo'>Svelte</a>
+		<section>
+			<span class="menu-link">Menu</span>
+			<a href='/' class='logo'>Svelte</a>
 
-		<ul class="navigation">
-			<li><a class='active' href='/guide'>Guide</a></li>
-			<li><a href='/repl'>REPL</a></li>
-			<li><a href='/blog'>Blog</a></li>
-			<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
-			<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
-		</ul>
+			<ul class="navigation">
+				<li><a class='active' href='/guide'>Guide</a></li>
+				<li><a href='/repl'>REPL</a></li>
+				<li><a href='/blog'>Blog</a></li>
+				<li><a href='https://gitter.im/sveltejs/svelte'>Chat</a></li>
+				<li><a href='https://github.com/sveltejs/svelte'>GitHub</a></li>
+			</ul>
+		</section>
 	</header>
 
 	<main>


### PR DESCRIPTION
### Current Status

<br>

![screen shot 2017-03-13 at 22 06 34](https://cloud.githubusercontent.com/assets/649779/23875408/a0736dea-0839-11e7-82a1-61cacac68a84.png)

<br>

![screen shot 2017-03-13 at 22 06 40](https://cloud.githubusercontent.com/assets/649779/23875412/a333e988-0839-11e7-9bad-9e960762271e.png)

<br>

![screen shot 2017-03-13 at 22 06 45](https://cloud.githubusercontent.com/assets/649779/23875416/a6a40620-0839-11e7-8b6a-1ce7f07501e5.png)

<br>
<br>

### Proposed Changes

<br>

![screen shot 2017-03-13 at 22 05 55](https://cloud.githubusercontent.com/assets/649779/23875473/e60cf312-0839-11e7-8c44-c0ab0cd9e1b7.png)

<br>

![screen shot 2017-03-13 at 22 06 08](https://cloud.githubusercontent.com/assets/649779/23875474/e8aa7554-0839-11e7-9789-ccbbd8ca4c56.png)

<br>

![screen shot 2017-03-13 at 22 06 12](https://cloud.githubusercontent.com/assets/649779/23875491/ebfecb38-0839-11e7-8f82-c526401b46a6.png)


I'm not fully convinced about the REPL idea.

Despite site asymmetry, given the interactive nature of the REPL it may make sense to think of it more like an app, with the main and sub navigation(s) completely left-aligned.

I thought reducing the mouse interaction area to the top left would help in ultra-wide configurations, but didn't want to shrink the REPL width to, say, the size of the guide's content.

Thoughts? 🙂