### PR TITLE
Improve homepage phrasing

### DIFF
--- a/shared/routes/Index.html
+++ b/shared/routes/Index.html
@@ -7,9 +7,9 @@
 		<h2>The magical disappearing UI framework</h2>
 
 		<ul>
-			<li><strong>The web's obesity crisis, solved.</strong> Svelte turns your templates into tiny, framework-less vanilla JavaScript.</li>
+			<li><strong>The web's JavaScript bloat crisis, solved.</strong> Svelte turns your templates into tiny, framework-less vanilla JavaScript.</li>
 			<li><strong>Simple and familiar.</strong> Build apps out of composable, easy-to-write blocks using languages you already know.</li>
-			<li><strong>Stupid fast, rock solid.</strong> Compile-time static analysis ensures the browser does no more work than it needs to.</li>
+			<li><strong>Super fast, rock solid.</strong> Compile-time static analysis ensures the browser does no more work than it needs to.</li>
 		</ul>
 
 		<a class='learn-svelte' href='/guide'>Learn Svelte</a>


### PR DESCRIPTION
Removes the words "obesity" and "stupid" to use more positive language as suggested by @wavebeem

Closes #13 