### PR TITLE
Fix DOCTYPE

### DIFF
--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -1,4 +1,4 @@
-<!doctype>
+<!doctype html>
 <html>
 <head>
 	<meta charset='utf-8'>


### PR DESCRIPTION
While I was taking a look at the page source, I noticed that it was using an invalid DOCTYPE and getting parsed in quirks mode as a result.

Using Firefox I didn't see any immediate difference in rendering after making this change, but I still figured I'd submit a PR to avoid accidental reliance on quirks in future changes. The Rollup website is also affected.

I decided to keep the newline which my editor inserted at the end of the file, given that it's used inconsistently in this repo right now.

_Seeing as I have the opportunity, I'd also like to say thanks for all the work you've put into your open source projects. It's inspiring to see someone willing and able to tackle so many large problems and find their own creative ways of solving them._