### PR TITLE
repl: fix displaying of error messages

### DIFF
--- a/shared/routes/Repl/CodeMirror.html
+++ b/shared/routes/Repl/CodeMirror.html
@@ -59,7 +59,6 @@
 		border-top: 1px solid rgb(200,0,0);
 		color: rgb(200,0,0);
 		z-index: 999;
-		opacity: 0;
 		-webkit-animation: fade-in 0.4s 1;
 		-webkit-animation-delay: 0.5s;
 		-webkit-animation-fill-mode: forwards;


### PR DESCRIPTION
There's some other animation stuff here that doesn't seem to be working and I couldn't figure out how it was supposed to work. But this `opacity: 0` was definitely breaking things. The error messages associated with the CodeMirror components were not actually visible.