### PR TITLE
Change deprecated onrender to oncreate

### DIFF
--- a/guide/00-introduction.md
+++ b/guide/00-introduction.md
@@ -45,7 +45,7 @@ const app = new App({
 app.set({ name: 'everybody' });
 
 // detach the component and clean everything up
-app.teardown();
+app.destroy();
 ```
 
 Congratulations, you've just learned about half of Svelte's API!

--- a/guide/01-component-api.md
+++ b/guide/01-component-api.md
@@ -112,7 +112,7 @@ To observe on a nested component, use refs:
 <Widget ref:widget/>
 <script>
 	export default {
-		onrender () {
+		oncreate () {
 			this.refs.widget.observe( 'xxx', () => {...});
 		}
 	};

--- a/guide/01-component-api.md
+++ b/guide/01-component-api.md
@@ -148,14 +148,14 @@ At first glance `component.on(...)` and `component.fire(...)` aren't particularl
 > `component.on(...)` and `component.observe(...)` look quite similar, but they have different purposes. Observers are useful for reacting to data flowing through your application and changing continuously over time, whereas events are good for modeling discrete moments such as 'the user made a selection, and this is what it is'.
 
 
-### component.teardown()
+### component.destroy()
 
-Removes the component from the DOM and removes any observers and event listeners that were created. This will also fire a `teardown` event:
+Removes the component from the DOM and removes any observers and event listeners that were created. This will also fire a `destroy` event:
 
 ```js
-component.on( 'teardown', () => {
+component.on( 'destroy', () => {
 	alert( 'goodbye!' ); // please don't do this
 });
 
-component.teardown();
+component.destroy();
 ```

--- a/guide/04-behaviour.md
+++ b/guide/04-behaviour.md
@@ -202,7 +202,7 @@ Soon, we'll learn about [event handlers](#event-handlers) – if you want, skip 
 
 Most of the time you can make do with the standard DOM events (the sort you'd add via `element.addEventListener`, such as `click`) but sometimes you might need custom events to handle gestures, for example.
 
-Custom events are just functions that take a node and a callback as their argument, and return an object with a `teardown` method that gets called when the element is removed from the page:
+Custom events are just functions that take a node and a callback as their argument, and return an object with a `destroy` method that gets called when the element is removed from the page:
 
 ```html
 <button on:longpress='set({ done: true })'>click and hold</button>
@@ -229,7 +229,7 @@ Custom events are just functions that take a node and a callback as their argume
 				node.addEventListener( 'mousedown', onmousedown, false );
 
 				return {
-					teardown () {
+					destroy () {
 						node.removeEventListener( 'mousedown', onmousedown, false );
 					}
 				};
@@ -283,6 +283,6 @@ const widget = new Widget({
 });
 ```
 
-...except that Svelte will ensure that the value of `baz` is kept in sync with the value of `dynamic` in the parent component, and takes care of tearing down the child component when the parent is torn down.
+...except that Svelte will ensure that the value of `baz` is kept in sync with the value of `dynamic` in the parent component, and takes care of destroying the child component when the parent is destroyed.
 
 > Component names should be capitalised, following the widely-used JavaScript convention of capitalising constructor names. It's also an easy way to distinguish components from elements in your template.

--- a/guide/05-element-directives.md
+++ b/guide/05-element-directives.md
@@ -138,11 +138,11 @@ Refs are a convenient way to store a reference to particular DOM nodes or compon
 			const canvas = this.refs.canvas;
 			const ctx = canvas.getContext( '2d' );
 
-			let torndown = false;
-			this.on( 'teardown', () => torndown = true );
+			let destroyed = false;
+			this.on( 'destroy', () => destroyed = true );
 
 			function loop () {
-				if ( torndown ) return;
+				if ( destroyed ) return;
 				requestAnimationFrame( loop );
 
 				const imageData = ctx.getImageData( 0, 0, canvas.width, canvas.height );

--- a/shared/components/GuideContents.html
+++ b/shared/components/GuideContents.html
@@ -57,7 +57,7 @@
 			};
 
 			window.addEventListener( 'hashchange', onhashchange, false );
-			this.on( 'teardown', () => {
+			this.on( 'destroy', () => {
 				window.removeEventListener( 'hashchange', onhashchange, false );
 			});
 

--- a/shared/routes/Guide.html
+++ b/shared/routes/Guide.html
@@ -255,7 +255,7 @@
 				setTimeout( onresize, 5000 )
 			];
 
-			this.on( 'teardown', () => {
+			this.on( 'destroy', () => {
 				window.removeEventListener( 'scroll', onscroll, true );
 				window.removeEventListener( 'resize', onresize, true );
 

--- a/shared/routes/Repl/CodeMirror.html
+++ b/shared/routes/Repl/CodeMirror.html
@@ -141,7 +141,7 @@
 				}
 			});
 
-			this.on( 'teardown', () => {
+			this.on( 'destroy', () => {
 				this.editor.toTextArea();
 			});
 		},

--- a/shared/routes/Repl/Viewer.html
+++ b/shared/routes/Repl/Viewer.html
@@ -154,13 +154,13 @@
 				let observers = null;
 				let updating = null;
 
-				let toTeardown = null;
+				let toDestroy = null;
 
 				this.observe( 'compiled', compiled => {
 					if ( !compiled ) return;
 					if ( promise ) promise.cancel();
 
-					toTeardown = component;
+					toDestroy = component;
 					component = null;
 
 					setTimeout( () => { // necessary because `data` is not yet updated. TODO would be nice to fix this
@@ -183,12 +183,12 @@
 						const createComponent = () => {
 							this.set({ error: null });
 
-							if ( toTeardown ) {
+							if ( toDestroy ) {
 								const styles = iframe.contentDocument.querySelectorAll( 'style' );
 								let i = styles.length;
 								while ( i-- ) styles[i].parentNode.removeChild( styles[i] );
 
-								toTeardown.teardown();
+								toDestroy.destroy();
 							}
 
 							imports.forEach( x => {

--- a/shared/routes/Repl/index.html
+++ b/shared/routes/Repl/index.html
@@ -517,7 +517,7 @@
 				node.addEventListener( 'mousedown', mousedown, false );
 
 				return {
-					teardown () {
+					destroy () {
 						node.removeEventListener( 'mousedown', onmousedown, false );
 					}
 				};


### PR DESCRIPTION
The deprecated method onrender() is used in one of the examples.
Change to oncreate().

See sveltejs/svelte#40