### PR TITLE
repl: mark App.html as the entry component when loading from a gist

### DIFF
--- a/shared/routes/Repl/utils/gist.js
+++ b/shared/routes/Repl/utils/gist.js
@@ -21,6 +21,7 @@ export function getComponentFromGist ( id ) {
 					// legacy
 					components.push({
 						name: 'App',
+						entry: true,
 						source: gist.files[ 'component.html' ].content
 					});
 				} else {
@@ -28,7 +29,7 @@ export function getComponentFromGist ( id ) {
 						const name = file.slice( 0, -5 );
 						const source = gist.files[ file ].content;
 
-						components.push({ name, source });
+						components.push({ name, entry: name === 'App', source });
 					});
 				}
 


### PR DESCRIPTION
Fixes #82.