### PR TITLE
Show origin of runtime errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ public/examples
 public/blog
 public/codemirror*
 public/rollup.browser.js
+public/svelte*
 shared/components/guide-summary.json
 shared/routes/Repl/examples.js
 server/components

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "codemirror": "^5.25.0",
     "curl-amd": "^0.8.12",
+    "locate-character": "^2.0.0",
     "roadtrip": "^0.4.1",
     "rollup": "^0.41.6",
     "sourcemap-codec": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "curl-amd": "^0.8.12",
     "roadtrip": "^0.4.1",
     "rollup": "^0.41.6",
+    "sourcemap-codec": "^1.3.1",
     "svelte": "^1.13.5"
   },
   "now": {

--- a/scripts/prep/build-components.js
+++ b/scripts/prep/build-components.js
@@ -1,36 +1,38 @@
-const fs = require( 'fs' );		
-const path = require( 'path' );		
-const rollup = require( 'rollup' );		
-const svelte = require( 'rollup-plugin-svelte' );		
-const json = require( 'rollup-plugin-json' );		
-const { mkdirp } = require( './utils.js' );		
-		
-const root = path.resolve( __dirname, '../..' );		
-		
-// generate bundles for each route, plus the nav		
-[		
-	'routes/Index',		
-	'routes/BlogIndex',		
-	'routes/BlogPost',		
-	'routes/Guide',		
-	'routes/Repl/index',		
-	'components/Nav'		
-].forEach( entry => {		
-	rollup.rollup({		
-		entry: `${root}/shared/${entry}.html`,		
-		plugins: [		
-			json(),		
-			svelte({		
-				generate: 'ssr',		
-				css: false		
-			})		
-		]		
-	}).then( bundle => {		
-		const { code } = bundle.generate({ format: 'cjs' });		
-		
-		const dest = `${root}/server/${entry}.js`;		
-		mkdirp( path.dirname( dest ) );		
-		
-		fs.writeFileSync( dest, code );		
-	});		
-}); 
+const fs = require( 'fs' );
+const path = require( 'path' );
+const rollup = require( 'rollup' );
+const svelte = require( 'rollup-plugin-svelte' );
+const resolve = require( 'rollup-plugin-node-resolve' );
+const json = require( 'rollup-plugin-json' );
+const { mkdirp } = require( './utils.js' );
+
+const root = path.resolve( __dirname, '../..' );
+
+// generate bundles for each route, plus the nav
+[
+	'routes/Index',
+	'routes/BlogIndex',
+	'routes/BlogPost',
+	'routes/Guide',
+	'routes/Repl/index',
+	'components/Nav'
+].forEach( entry => {
+	rollup.rollup({
+		entry: `${root}/shared/${entry}.html`,
+		plugins: [
+			resolve(),
+			json(),
+			svelte({
+				generate: 'ssr',
+				css: false
+			})
+		]
+	}).then( bundle => {
+		const { code } = bundle.generate({ format: 'cjs' });
+
+		const dest = `${root}/server/${entry}.js`;
+		mkdirp( path.dirname( dest ) );
+
+		fs.writeFileSync( dest, code );
+	});
+});

--- a/scripts/prep/build-repl.js
+++ b/scripts/prep/build-repl.js
@@ -2,3 +2,4 @@ const { copy } = require( './utils.js' );
 
 copy( `node_modules/codemirror/lib/codemirror.css`, `public/codemirror.css` );
 copy( `node_modules/rollup/dist/rollup.browser.js`, `public/rollup.browser.js` );
+copy( `node_modules/svelte/compiler/svelte.js`, `public/svelte.js` );

--- a/server/index.js
+++ b/server/index.js
@@ -16,10 +16,12 @@ function renderComponent ( file, data ) {
 		const rollup = require( 'rollup' );
 		const json = require( 'rollup-plugin-json' );
 		const svelte = require( 'rollup-plugin-svelte' );
+		const resolve = require( 'rollup-plugin-node-resolve' );
 
 		return rollup.rollup({
 			entry: `${root}/shared/${file}.html`,
 			plugins: [
+				resolve(),
 				json(),
 				svelte({
 					generate: 'ssr',

--- a/shared/routes/Repl/CodeMirror.html
+++ b/shared/routes/Repl/CodeMirror.html
@@ -2,9 +2,16 @@
 	<textarea tabindex='2' ref:editor></textarea>
 
 	{{#if error}}
-		<div class='error'>
+		<p class='error message'>
+			<strong>
+				{{#if error.filename}}
+					<span class='filename' on:click='fire("navigate", error.filename)'>{{error.filename}}</span>
+				{{/if}}
+
+				({{error.loc.line}}:{{error.loc.column}})
+			</strong>
 			{{error.message}}
-		</div>
+		</p>
 	{{/if}}
 </div>
 
@@ -52,45 +59,20 @@
 	}
 
 	.error {
+		bottom: 1em;
+		left: 1em;
 		position: absolute;
-		width: 100%;
-		bottom: 0;
-		padding: 0.5em;
-		background-color: rgb(255,220,220);
-		border-top: 1px solid rgb(200,0,0);
-		color: rgb(200,0,0);
-		z-index: 999;
-		-webkit-animation: fade-in 0.4s 1;
-		-webkit-animation-delay: 0.5s;
-		-webkit-animation-fill-mode: forwards;
-		animation: fade-in 0.4s 1;
-		animation-delay: 0.5s;
-		animation-fill-mode: forwards;
+		z-index: 20;
 	}
 
 	.error-loc {
 		position: relative;
+		/*background-color: rgba(200,0,30,0.1);*/
+		border-bottom: 2px solid rgb(200,0,0);
 	}
 
-	.error-loc::before {
-		position: absolute;
-		content: '^';
-		display: inline-block;
-		bottom: -1.2em;
-		left: -0.2em;
-		/*background-color: rgb(200,0,0);
-		color: white;*/
-		background-color: white;
-		color: rgb(200,0,0);
-		font-size: 1em;
-		font-weight: 500;
-		/*width: 1em;
-		height: 1em;*/
-		/*padding: 0.1em;
-		text-align: center;*/
-		border-radius: 50%;
-		-webkit-animation: pulse 1s infinite;
-		animation: pulse 1s infinite;
+	.error-line {
+		background-color: rgba(200,0,0,0.05);
 	}
 </style>
 
@@ -99,6 +81,14 @@
 		oncreate () {
 			let updating = false;
 
+			const modeName = this.get( 'mode' );
+			const mode = modeName === 'json' ? {
+				name: 'javascript',
+				json: true
+			} : {
+				name: modeName
+			};
+
 			this.editor = window.CodeMirror.fromTextArea( this.refs.editor, {
 				lineNumbers: true,
 				lineWrapping: true,
@@ -106,7 +96,7 @@
 				indentUnit: 2,
 				tabSize: 2,
 				value: this.get( 'code' ),
-				mode: this.get( 'mode' ),
+				mode,
 				readOnly: this.get( 'readonly' )
 			});
 
@@ -133,15 +123,27 @@
 			});
 
 			let marker;
-			this.observe( 'error', error => {
+			let line;
+			this.observe( 'errorLoc', loc => {
 				if ( marker ) marker.clear();
-				if ( error && error.pos != null ) {
-					const { line, ch } = this.editor.getDoc().posFromIndex( error.pos );
+
+				if ( loc == null ) {
+					this.set({ errorLine: null });
+				} else {
+					const line = loc.line - 1;
+					const ch = loc.column;
 
 					marker = this.editor.markText({ line, ch }, { line, ch: ch + 1 }, {
 						className: 'error-loc'
 					});
+
+					this.set({ errorLine: line });
 				}
+			});
+
+			this.observe( 'errorLine', ( line, previousLine ) => {
+				if ( previousLine != null ) this.editor.removeLineClass( previousLine, 'wrap', 'error-line' );
+				if ( line != null ) this.editor.addLineClass( line, 'wrap', 'error-line' );
 			});
 
 			this.on( 'destroy', () => {

--- a/shared/routes/Repl/Viewer.html
+++ b/shared/routes/Repl/Viewer.html
@@ -12,7 +12,13 @@
 
 <div class='overlay'>
 	{{#if error}}
-		<p class='error'>{{error.message}}</p>
+		<p class='error'>
+			{{#if errorLocation}}
+				<strong>{{errorLocation.source}} ({{errorLocation.line}}:{{errorLocation.column}})</strong>
+			{{/if}}
+
+			{{error.message}}
+		</p>
 	{{elseif pendingImports}}
 		<p class='info'>loading {{pendingImports}} {{pendingImports === 1 ? 'dependency' : 'dependencies'}} from packd.now.sh (this may take a while if the package isn't cached)</p>
 	{{/if}}
@@ -90,6 +96,9 @@
 </style>
 
 <script>
+	import getLocationFromStack from './utils/getLocationFromStack.js';
+	import { decode } from 'sourcemap-codec';
+
 	let importCache = {};
 
 	function fetchImport ( id ) {
@@ -170,7 +179,7 @@
 						const missingImports = bundle.imports.filter( x => !importCache[ x ] );
 
 						const createComponent = () => {
-							this.set({ error: null });
+							this.set({ error: null, errorLocation: null });
 
 							if ( toDestroy ) {
 								const styles = iframe.contentDocument.querySelectorAll( 'style' );
@@ -190,14 +199,12 @@
 							const data = this.get( 'data' );
 
 							try {
-								evalInIframe( `
-									${bundle.code}
+								evalInIframe( `${bundle.code}
 									document.body.innerHTML = '';
 									var component = new SvelteComponent({
 										target: document.body,
 										data: ${JSON.stringify(data)}
-									});
-								`);
+									});`);
 
 								component = window.component = iframe.contentWindow.component;
 
@@ -215,9 +222,12 @@
 								component = null;
 								observers = null;
 
+								const errorLocation = getLocationFromStack( error.stack, bundle.map );
+
+								console.log( `errorLocation`, errorLocation )
 								console.error( error.stack );
 
-								this.set({ error });
+								this.set({ error, errorLocation });
 							}
 						};
 

--- a/shared/routes/Repl/Viewer.html
+++ b/shared/routes/Repl/Viewer.html
@@ -66,6 +66,10 @@
 		padding: 1em;
 		pointer-events: none;
 	}
+
+	.overlay p {
+		pointer-events: all;
+	}
 </style>
 
 <script>

--- a/shared/routes/Repl/Viewer.html
+++ b/shared/routes/Repl/Viewer.html
@@ -12,15 +12,21 @@
 
 <div class='overlay'>
 	{{#if error}}
-		<p class='error'>
-			{{#if errorLocation}}
-				<strong>{{errorLocation.source}} ({{errorLocation.line}}:{{errorLocation.column}})</strong>
+		<p class='error message'>
+			{{#if error.loc}}
+				<strong>
+					{{#if error.filename}}
+						<span class='filename' on:click='fire("navigate", error.filename)'>{{error.filename}}</span>
+					{{/if}}
+
+					({{error.loc.line}}:{{error.loc.column}})
+				</strong>
 			{{/if}}
 
 			{{error.message}}
 		</p>
 	{{elseif pendingImports}}
-		<p class='info'>loading {{pendingImports}} {{pendingImports === 1 ? 'dependency' : 'dependencies'}} from packd.now.sh (this may take a while if the package isn't cached)</p>
+		<p class='info message'>loading {{pendingImports}} {{pendingImports === 1 ? 'dependency' : 'dependencies'}} from packd.now.sh (this may take a while if the package isn't cached)</p>
 	{{/if}}
 </div>
 
@@ -59,39 +65,6 @@
 		width: 100%;
 		padding: 1em;
 		pointer-events: none;
-	}
-
-	.overlay p {
-		position: relative;
-		border-radius: 0.2em;
-		margin: 0;
-		padding: 0.5em 0.5em 0.5em 2.5em;
-		color: white;
-	}
-
-	.overlay p::before {
-		content: '!';
-		position: absolute;
-		left: 0.7em;
-		top: 0.55em;
-		font-size: 0.8em;
-		font-weight: 800;
-		width: 1em;
-		height: 1em;
-		text-align: center;
-		line-height: 1;
-		padding: 0.2em 0.15em 0.1em 0.15em;
-		border-radius: 50%;
-		color: white;
-		border: 2px solid white;
-	}
-
-	.error {
-		background-color: rgb(170,30,30);
-	}
-
-	.info {
-		background-color: #666;
 	}
 </style>
 
@@ -165,6 +138,97 @@
 
 				let toDestroy = null;
 
+				const init = () => {
+					const { bundle } = this.get();
+
+					const imports = [];
+					const pattern = /\bimport\s+(?:(.+)\s+from\s+)?[\'"]([^"\']+)["\']/g; // https://gist.github.com/pilwon/ff55634a29bb4456e0dd
+
+					const missingImports = bundle.imports.filter( x => !importCache[ x ] );
+
+					const createComponent = () => {
+						this.set({ error: null });
+
+						if ( toDestroy ) {
+							const styles = iframe.contentDocument.querySelectorAll( 'style' );
+							let i = styles.length;
+							while ( i-- ) styles[i].parentNode.removeChild( styles[i] );
+
+							toDestroy.destroy();
+							toDestroy = null;
+						}
+
+						bundle.imports.forEach( x => {
+							const module = importCache[ x ];
+							const name = bundle.importMap.get( x );
+
+							iframe.contentWindow[ name ] = module;
+						});
+
+						const data = this.get( 'data' );
+
+						try {
+							evalInIframe( `${bundle.code}
+								document.body.innerHTML = '';
+								var component = new SvelteComponent({
+									target: document.body,
+									data: ${JSON.stringify(data)}
+								});`);
+
+							component = window.component = iframe.contentWindow.component;
+
+							observers = Object.keys( data ).map( key => {
+								return component.observe( key, value => {
+									if ( updating ) return;
+
+									updating = true;
+									this.fire( 'change', { key, value });
+									updating = false;
+								}, { init: false });
+							});
+						} catch ( error ) {
+							// TODO show in UI
+							component = null;
+							observers = null;
+
+							const loc = getLocationFromStack( error.stack, bundle.map );
+							if ( loc ) {
+								error.filename = loc.source;
+								error.loc = { line: loc.line, column: loc.column };
+							}
+							this.set({ error });
+						}
+					};
+
+					let pendingImports = missingImports.length;
+					this.set({ pendingImports });
+
+					if ( missingImports.length ) {
+						let cancelled = false;
+
+						promise = Promise.all(
+							missingImports.map( id => fetchImport( id ).then( module => {
+								pendingImports -= 1;
+								this.set({ pendingImports });
+								return module;
+							}))
+						);
+						promise.cancel = () => cancelled = true;
+
+						promise
+							.then( () => {
+								if ( cancelled ) return;
+								createComponent();
+							})
+							.catch( error => {
+								if ( cancelled ) return;
+								this.set({ error });
+							});
+					} else {
+						createComponent();
+					}
+				}
+
 				this.observe( 'bundle', bundle => {
 					if ( !bundle ) return; // TODO can this ever happen?
 					if ( promise ) promise.cancel();
@@ -172,93 +236,7 @@
 					toDestroy = component;
 					component = null;
 
-					setTimeout( () => { // necessary because `data` is not yet updated. TODO would be nice to fix this
-						const imports = [];
-						const pattern = /\bimport\s+(?:(.+)\s+from\s+)?[\'"]([^"\']+)["\']/g; // https://gist.github.com/pilwon/ff55634a29bb4456e0dd
-
-						const missingImports = bundle.imports.filter( x => !importCache[ x ] );
-
-						const createComponent = () => {
-							this.set({ error: null, errorLocation: null });
-
-							if ( toDestroy ) {
-								const styles = iframe.contentDocument.querySelectorAll( 'style' );
-								let i = styles.length;
-								while ( i-- ) styles[i].parentNode.removeChild( styles[i] );
-
-								toDestroy.destroy();
-							}
-
-							bundle.imports.forEach( x => {
-								const module = importCache[ x ];
-								const name = bundle.importMap.get( x );
-
-								iframe.contentWindow[ name ] = module;
-							});
-
-							const data = this.get( 'data' );
-
-							try {
-								evalInIframe( `${bundle.code}
-									document.body.innerHTML = '';
-									var component = new SvelteComponent({
-										target: document.body,
-										data: ${JSON.stringify(data)}
-									});`);
-
-								component = window.component = iframe.contentWindow.component;
-
-								observers = Object.keys( data ).map( key => {
-									return component.observe( key, value => {
-										if ( updating ) return;
-
-										updating = true;
-										this.fire( 'change', { key, value });
-										updating = false;
-									}, { init: false });
-								});
-							} catch ( error ) {
-								// TODO show in UI
-								component = null;
-								observers = null;
-
-								const errorLocation = getLocationFromStack( error.stack, bundle.map );
-
-								console.log( `errorLocation`, errorLocation )
-								console.error( error.stack );
-
-								this.set({ error, errorLocation });
-							}
-						};
-
-						let pendingImports = missingImports.length;
-						this.set({ pendingImports });
-
-						if ( missingImports.length ) {
-							let cancelled = false;
-
-							promise = Promise.all(
-								missingImports.map( id => fetchImport( id ).then( module => {
-									pendingImports -= 1;
-									this.set({ pendingImports });
-									return module;
-								}))
-							);
-							promise.cancel = () => cancelled = true;
-
-							promise
-								.then( () => {
-									if ( cancelled ) return;
-									createComponent();
-								})
-								.catch( error => {
-									if ( cancelled ) return;
-									this.set({ error });
-								});
-						} else {
-							createComponent();
-						}
-					});
+					setTimeout( init ); // necessary because `data` is not yet updated. TODO would be nice to fix this
 				});
 
 				this.observe( 'data', data => {
@@ -268,6 +246,7 @@
 						}
 
 						if ( component ) {
+							this.set({ error: null });
 							updating = true;
 							component.set( data );
 							updating = false;
@@ -281,10 +260,16 @@
 									updating = false;
 								}, { init: false });
 							});
+						} else {
+							init();
 						}
-					} catch ( err ) {
-						// TODO show the error in the UI
-						console.error( err );
+					} catch ( error ) {
+						const loc = getLocationFromStack( error.stack, this.get( 'bundle' ).map );
+						if ( loc ) {
+							error.filename = loc.source;
+							error.loc = { line: loc.line, column: loc.column };
+						}
+						this.set({ error });
 					}
 				});
 			});

--- a/shared/routes/Repl/index.html
+++ b/shared/routes/Repl/index.html
@@ -26,7 +26,14 @@
 						{{#if showGenerated && selectedComponent.compiled}}
 							<CodeMirror ref:editor mode='javascript' code='{{selectedComponent.compiled.code}}' readonly/>
 						{{else}}
-							<CodeMirror ref:editor mode='htmlmixed' bind:code='selectedComponent.source' error='{{sourceError}}'/>
+							<CodeMirror
+								ref:editor
+								mode='htmlmixed'
+								bind:code='selectedComponent.source'
+								error='{{sourceError}}'
+								errorLoc='{{sourceErrorLoc || runtimeErrorLoc}}'
+								on:navigate='navigate(event)'
+							/>
 						{{/if}}
 					{{/if}}
 
@@ -44,7 +51,7 @@
 		<h2 class='show-if-mobile'>data.json</h2>
 		<div class='bottom' style='height: {{100 - horizontalDividerPos}}%;'>
 			{{#if loadedCodemirror}}
-				<CodeMirror ref:data mode='javascript' bind:code='json' error='{{dataError}}'/>
+				<CodeMirror ref:data mode='javascript' bind:code='json' error='{{dataError}}' errorLoc='{{dataErrorLoc}}'/>
 			{{else}}
 				<p class='loading'>loading editor...</p>
 			{{/if}}
@@ -54,7 +61,7 @@
 		<div class='top' style='height: {{horizontalDividerPos}}%;'>
 			{{#if loadedSvelte}}
 				{{#if bundle}}
-					<Viewer :bundle :data on:change='updateData(event)'/>
+					<Viewer :bundle :data bind:error='runtimeError' on:change='updateData(event)' on:navigate='navigate(event)'/>
 				{{/if}}
 			{{else}}
 				<p class='loading'>loading Svelte compiler...</p>
@@ -361,9 +368,47 @@
 		height: 100%;
 		background: rgba(255,255,255,0.01);
 	}
+
+	.message {
+		position: relative;
+		border-radius: 0.2em;
+		margin: 0;
+		padding: 0.5em 0.5em 0.5em 2.5em;
+		color: white;
+	}
+
+	.message::before {
+		content: '!';
+		position: absolute;
+		left: 0.7em;
+		top: 0.55em;
+		font-size: 0.8em;
+		font-weight: 800;
+		width: 1em;
+		height: 1em;
+		text-align: center;
+		line-height: 1;
+		padding: 0.2em 0.15em 0.1em 0.15em;
+		border-radius: 50%;
+		color: white;
+		border: 2px solid white;
+	}
+
+	.error.message {
+		background-color: rgb(170,30,30);
+	}
+
+	.info.message {
+		background-color: #666;
+	}
+
+	.error .filename {
+		cursor: pointer;
+	}
 </style>
 
 <script>
+	import { locate } from 'locate-character';
 	import CodeMirror from './CodeMirror.html';
 	import Viewer from './Viewer.html';
 	import ComponentSelector from './ComponentSelector.html';
@@ -486,6 +531,15 @@
 				editorRotation: 0,
 				flip: ''
 			};
+		},
+
+		computed: {
+			runtimeErrorLoc ( runtimeError, selectedComponent ) {
+				if ( !runtimeError || !selectedComponent ) return null;
+				if ( runtimeError.filename !== `${selectedComponent.name}.html` ) return;
+
+				return runtimeError.loc;
+			}
 		},
 
 		methods: {
@@ -728,6 +782,17 @@
 				const url = queryString ? `/repl?${queryString}` : '/repl';
 
 				history.replaceState( {}, 'x', url );
+			},
+
+			navigate ( filename ) {
+				const name = filename.replace( /\.html$/, '' );
+				const { components, selectedComponent } = this.get();
+
+				if ( selectedComponent.name === name ) return;
+
+				this.set({
+					selectedComponent: components.find( c => c.name === name )
+				});
 			}
 		},
 
@@ -808,7 +873,8 @@
 						console.error( err.stack );
 
 						this.set({
-							sourceError: { message: err.shortMessage || err.message, pos: err.pos }
+							sourceError: err,
+							sourceErrorLoc: err.loc
 						});
 					}
 				});
@@ -823,16 +889,15 @@
 
 					try {
 						selectedComponent.compiled = compile( selectedComponent );
-						this.set({ selectedComponent, sourceError: null });
+						this.set({ selectedComponent, sourceError: null, sourceErrorLoc: null });
 
 						if ( this.get( 'loadedRollup' ) ) {
 							this.updateBundle();
 						}
 					} catch ( err ) {
-						console.error( err.stack );
-
 						this.set({
-							sourceError: { message: err.shortMessage || err.message, pos: err.pos }
+							sourceError: err,
+							sourceErrorLoc: err.loc
 						});
 					}
 				});
@@ -848,25 +913,27 @@
 			});
 
 			this.observe( 'json', json => {
-				let data;
-
 				try {
-					data = JSON.parse( json );
-					this.set({ dataError: null });
+					this.set({
+						data: JSON.parse( json ),
+						dataError: null,
+						dataErrorLoc: null
+					});
 				} catch ( err ) {
 					console.error( err.stack );
 
-					const match = /(.+)in JSON at position (\d+)/.exec( err.message );
+					const match = /in JSON at position (\d+)/.exec( err.message );
 
 					if ( match ) {
+						const loc = locate( json, +match[1], { offsetLine: 1 });
 						this.set({
-							dataError: { message: match[1], pos: +match[2] }
+							dataError: {
+								message: err.message.slice( 0, match.index ).trim(),
+								loc
+							},
+							dataErrorLoc: loc
 						});
 					}
-				}
-
-				if ( data ) {
-					this.set({ data });
 				}
 			});
 		},

--- a/shared/routes/Repl/index.html
+++ b/shared/routes/Repl/index.html
@@ -388,6 +388,7 @@
 
 	function loadSvelte () {
 		const url = versionMatch ?
+			versionMatch[1] === 'local' ? '/svelte.js' :
 			'https://unpkg.com/svelte@' + versionMatch[1] + '/compiler/svelte.js' :
 			'https://unpkg.com/svelte/compiler/svelte.js';
 
@@ -409,6 +410,13 @@
 				if ( group.examples[j].id === id ) return group.examples[j];
 			}
 		}
+	}
+
+	function compile ( component ) {
+		return svelte.compile( component.source || '', {
+			name: component.name,
+			filename: component.name + '.html'
+		});
 	}
 
 	export default {
@@ -640,7 +648,7 @@
 
 				const lookup = {};
 				components.forEach( component => {
-					lookup[ `\0${component.name}.html` ] = component.compiled;
+					lookup[ `./${component.name}.html` ] = component.compiled;
 				});
 
 				let cancelled = false;
@@ -652,14 +660,14 @@
 				this.bundlePromise = rollup.rollup({
 					entry,
 					external: id => {
-						return id.charCodeAt( 0 ) > 0 && id[0] !== '.';
+						return id[0] !== '.';
 					},
 					plugins: [{
 						resolveId ( importee, importer ) {
-							if ( importee[0] === '.' ) return `\0${importee.slice( 2 )}`;
+							if ( importee[0] === '.' ) return importee;
 						},
 						load ( id ) {
-							return lookup[ id ];
+							return lookup[ `${id}` ];
 						}
 					}],
 					onwarn ( warning ) {
@@ -676,7 +684,8 @@
 							const name = `import_${uid++}`;
 							importMap.set( id, name );
 							return name;
-						}
+						},
+						sourceMap: true
 					});
 
 					this.set({
@@ -702,7 +711,7 @@
 
 				const params = {};
 				if ( typeof svelte !== 'undefined' ) {
-					params.version = svelte.VERSION;
+					params.version = versionMatch && versionMatch[1] === 'local' ? 'local' : svelte.VERSION;
 				} else if ( versionMatch ) {
 					params.version = versionMatch[1];
 				}
@@ -745,10 +754,7 @@
 					// compile non-selected components
 					if ( window.svelte ) {
 						example.components.slice( 1 ).forEach( component => {
-							component.compiled = svelte.compile( component.source, {
-								name: component.name,
-								filename: component.name + '.html'
-							});
+							component.compiled = compile( component );
 						});
 					}
 
@@ -797,10 +803,7 @@
 					if ( component === this.get( 'selectedComponent' ) ) return;
 
 					try {
-						component.compiled = svelte.compile( component.source || '', {
-							name: component.name,
-							filename: component.name + '.html'
-						});
+						component.compiled = compile( component );
 					} catch ( err ) {
 						console.error( err.stack );
 
@@ -819,10 +822,7 @@
 					}
 
 					try {
-						selectedComponent.compiled = svelte.compile( selectedComponent.source || '', {
-							name: selectedComponent.name,
-							filename: selectedComponent.name + '.html'
-						});
+						selectedComponent.compiled = compile( selectedComponent );
 						this.set({ selectedComponent, sourceError: null });
 
 						if ( this.get( 'loadedRollup' ) ) {

--- a/shared/routes/Repl/utils/getLocationFromStack.js
+++ b/shared/routes/Repl/utils/getLocationFromStack.js
@@ -1,0 +1,31 @@
+import { decode } from 'sourcemap-codec';
+
+export default function getLocationFromStack ( stack, map ) {
+	if ( !stack ) return;
+	const last = stack.split( '\n' )[1];
+	const match = /<anonymous>:(\d+):(\d+)\)$/.exec( last );
+
+	if ( !match ) return null;
+
+	const line = +match[1];
+	const column = +match[2];
+
+	return trace( { line, column }, map );
+}
+
+function trace ( loc, map ) {
+	const mappings = decode( map.mappings );
+	const segments = mappings[ loc.line - 1 ];
+
+	for ( let i = 0; i < segments.length; i += 1 ) {
+		const segment = segments[i];
+		if ( segment[0] === loc.column ) {
+			const [ , sourceIndex, line, column ] = segment;
+			const source = map.sources[ sourceIndex ].slice( 2 );
+
+			return { source, line: line + 1, column };
+		}
+	}
+
+	return null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,6 +1595,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+locate-character@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-2.0.0.tgz#8eb94df3a899e53c8d4cee6d13c9effb76213699"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,6 +2461,12 @@ source-map@0.5.x, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+sourcemap-codec@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.3.1.tgz#9ad6f9bdbd691931016e30939dbc868673323146"
+  dependencies:
+    vlq "^0.2.1"
+
 split-array@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split-array/-/split-array-1.0.1.tgz#7d0c10366705f3aa4620529ab755bf7ed2220da1"


### PR DESCRIPTION
This falls under #39. When an error occurs, it's often possible to trace the last item in the stack back to a location in the component source code. We can use that information to help users diagnose the error.

I've got as far as this:

<img width="906" alt="screen shot 2017-04-12 at 11 46 45 pm" src="https://cloud.githubusercontent.com/assets/1162160/24989391/5946b414-1fda-11e7-909c-bf95eada660e.png">

* [x] Next step is to highlight that location in the editor, the same way compile errors are indicated
* [x] It seems to be a little wonky with multiple components — the source index is always 0, for some reason. Need to fix that before this can be merged
* [ ] Right now this only pertains to errors that happen when the component is first created. Not sure if we want to try and do the same for errors that happen after that point (or if that's even possible)