### PR TITLE
repl: in CodeMirror component, deal with `error.loc` being undefined

### DIFF
--- a/shared/routes/Repl/CodeMirror.html
+++ b/shared/routes/Repl/CodeMirror.html
@@ -3,13 +3,16 @@
 
 	{{#if error}}
 		<p class='error message'>
-			<strong>
-				{{#if error.filename}}
-					<span class='filename' on:click='fire("navigate", error.filename)'>{{error.filename}}</span>
-				{{/if}}
+			{{#if error.loc}}
+				<strong>
+					{{#if error.filename}}
+						<span class='filename' on:click='fire("navigate", error.filename)'>{{error.filename}}</span>
+					{{/if}}
 
-				({{error.loc.line}}:{{error.loc.column}})
-			</strong>
+					({{error.loc.line}}:{{error.loc.column}})
+				</strong>
+			{{/if}}
+
 			{{error.message}}
 		</p>
 	{{/if}}


### PR DESCRIPTION
Fixes the particular instance of #89 that I was seeing. I've made the error message display in `CodeMirror.html` align with that in `Viewer.html`, so that if `error.loc` is undefined, it won't crash the whole REPL.