### PR TITLE
Nav component: add overflow-y only when open

### DIFF
--- a/shared/components/Nav.html
+++ b/shared/components/Nav.html
@@ -67,12 +67,12 @@
 		z-index: 5;
 		padding: 1em;
 		user-select: none;
-		overflow-y: auto;
 	}
 
 	.open {
 		transform: translate(0,0);
 		transition: transform 0.3s cubic-bezier(.17,.67,.24,.99);
+		overflow-y: auto;
 	}
 
 	.menu-link {


### PR DESCRIPTION
Fixes nav display in Safari #95 