### PR TITLE
destroy _svelteTransitionManager when creating fresh components

### DIFF
--- a/universal/routes/Repl/Viewer.html
+++ b/universal/routes/Repl/Viewer.html
@@ -214,6 +214,7 @@
 						try {
 							evalInIframe( `${bundle.code}
 								document.body.innerHTML = '';
+								window._svelteTransitionManager = null;
 								var component = new SvelteComponent({
 									target: document.body,
 									data: ${JSON.stringify(data)}


### PR DESCRIPTION
fixes #121 