### PR TITLE
document `component.get()` with no arguments

### DIFF
--- a/content/guide/01-component-api.md
+++ b/content/guide/01-component-api.md
@@ -56,6 +56,8 @@ console.log( component.get( 'answer' ) ); // 'ask your mother'
 
 This will also retrieve the value of [computed properties](#computed-properties).
 
+You can also call `component.get()` without any arguments to retrieve an object of all keys and values, including computed properties.
+
 
 ### component.observe(key, callback[, options])
 

--- a/content/guide/01-component-api.md
+++ b/content/guide/01-component-api.md
@@ -56,7 +56,11 @@ console.log( component.get( 'answer' ) ); // 'ask your mother'
 
 This will also retrieve the value of [computed properties](#computed-properties).
 
-You can also call `component.get()` without any arguments to retrieve an object of all keys and values, including computed properties.
+You can also call `component.get()` without any arguments to retrieve an object of all keys and values, including computed properties. This works particularly nicely with ES6 destructuring:
+
+```js
+const { foo, bar, baz } = component.get();
+```
 
 
 ### component.observe(key, callback[, options])


### PR DESCRIPTION
Noticed this wasn't mentioned in the guide.