### PR TITLE
don't handle POST requests in service worker

### DIFF
--- a/templates/service-worker.js
+++ b/templates/service-worker.js
@@ -31,6 +31,7 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
 	const url = new URL(event.request.url);
 	if (!/^https?/.test(url.protocol)) return;
+	if (event.request.method === 'POST') return;
 
 	// always serve assets and webpack-generated files from cache
 	if (cached.has(url.pathname)) {


### PR DESCRIPTION
The REPL is failing to save-as-gist, apparently because the service worker balks at POST requests