### PR TITLE
fix typo in temperature converter example

### DIFF
--- a/content/examples/7guis-temperature/App.html
+++ b/content/examples/7guis-temperature/App.html
@@ -1,6 +1,6 @@
 <!-- https://github.com/eugenkiss/7guis/wiki#temperature-converter -->
 <input bind:value='celsius' type='number'> °c =
-<input bind:value='fahrenheight' type='number'> °f
+<input bind:value='fahrenheit' type='number'> °f
 
 <style>
 	input {
@@ -13,11 +13,11 @@
 		oncreate: function () {
 			this.observe( 'celsius', c => {
 				this.set({
-					fahrenheight: +( 32 + ( 9 / 5 * c ) ).toFixed( 1 )
+					fahrenheit: +( 32 + ( 9 / 5 * c ) ).toFixed( 1 )
 				});
 			});
 
-			this.observe( 'fahrenheight', f => {
+			this.observe( 'fahrenheit', f => {
 				this.set({
 					celsius: +( 5 / 9 * ( f - 32 ) ).toFixed( 1 )
 				});


### PR DESCRIPTION
fahrenheight ➜ fahrenheit