### PR TITLE
update SSR docs

### DIFF
--- a/content/guide/09-server-side-rendering.md
+++ b/content/guide/09-server-side-rendering.md
@@ -5,53 +5,92 @@ title: Server-side rendering
 So far, we've discussed creating Svelte components *on the client*, which is to say the browser. But you can also render Svelte components in Node.js. This can result in better perceived performance as it means the application starts rendering while the page is still downloading, before any JavaScript executes. It also has SEO advantages in some cases, and can be beneficial for people running older browsers that can't or won't run your JavaScript for whatever reason.
 
 
-### Rendering HTML
+### Using the compiler
 
-To use the server-side renderer, we must first *register* it. This means that when you `require` a component `.html` file, it gets intercepted by the SSR compiler:
-
-```js
-require( 'svelte/ssr/register' );
-```
-
-If on the other hand you use a different extension than `.html` (eg. `.svelte`), you need to bootstrap the SSR compiler by passing an [options](#ssr-options) object:
+If you're using the Svelte compiler, whether directly or via an integration like [rollup-plugin-svelte](https://github.com/rollup/rollup-plugin-svelte) or [svelte-loader](https://github.com/sveltejs/svelte-loader), you can tell it to generate a server-side component by passing the `generate: 'ssr'` option:
 
 ```js
-require( 'svelte/ssr/register' )({
-  extensions: ['.svelte']
+const { code } = svelte.compile(source, {
+	generate: 'ssr' // as opposed to 'dom', the default
 });
 ```
 
-After that, you can load components like so:
+
+### Registering Svelte
+
+Alternatively, an easy way to use the server-side renderer is to *register* it:
 
 ```js
-const thing = require( './components/Thing.html' );
+require('svelte/ssr/register');
 ```
 
-Components have a different API in Node.js – rather than creating instances with `set(...)` and `get(...)` methods, a component is an object with a `render(data)` method which returns HTML (the `data` object is the same as you would use when instantiating a component in the browser, and is optional):
+Now you can `require` your components:
 
 ```js
+const Thing = require('./components/Thing.html');
+```
+
+If you prefer to use a different file extension, or need to use [stores](#state-management), you can pass options like so:
+
+```js
+require('svelte/ssr/register')({
+	extensions: ['.svelte'],
+	store: true
+});
+```
+
+
+### Server-side API
+
+Components have a different API in Node.js – rather than creating instances with `set(...)` and `get(...)` methods, a component is an object with a `render(data, options)` method:
+
+```js
+require('svelte/ssr/register');
+const Thing = require('./components/Thing.html');
+
 const data = { answer: 42 };
-const html = thing.render( data );
+const { html, css, head } = Thing.render(data);
 ```
 
-Any [default data](#default-data), [computed properties](#computed-properties), [helpers](#helpers) and [nested components](#nested-components) will work as expected.
+All your [default data](#default-data), [computed properties](#computed-properties), [helpers](#helpers) and [nested components](#nested-components) will work as expected.
+
+Any `oncreate` functions or component methods will *not* run — these only apply to client-side components.
 
 > The SSR compiler will generate a CommonJS module for each of your components – meaning that `import` and `export` statements are converted into their `require` and `module.exports` equivalents. If your components have non-component dependencies, they must also work as CommonJS modules in Node. If you're using ES2015 modules, we recommend [@std/esm](https://github.com/standard-things/esm) for automatically converting them to CommonJS.
 
 
-### Rendering CSS
 
-You can also render your component's ([scoped](#scoped-styles)) CSS, including that of any nested components:
+#### Using stores
+
+If your components use [stores](#state-management), use the second argument:
 
 ```js
-const { css, components } = thing.renderCss();
+const { Store } = require('svelte/store.umd.js');
+
+const { html } = Thing.render(data, {
+	store: new Store({
+		foo: 'bar'
+	})
+});
+```
+
+
+#### Rendering styles
+
+You can also extract any [scoped styles](#scoped-styles) that are used by the component or its children:
+
+```js
+const { css } = Thing.render(data);
 ```
 
 You could put the resulting `css` in a separate stylesheet, or include them in the page inside a `<style>` tag. If you do this, you will probably want to prevent the client-side compiler from including the CSS again. For `svelte-cli`, use the `--no-css` flag. In build tool integrations like `rollup-plugin-svelte`, pass the `css: false` option.
 
-> The `components` array contains an object for each nested component that contains styles, allowing you to dedupe styles across multiple top-level components. Most of the time, you won't need to do this.
 
-### SSR Options
-| | **Values** | **Description** | **Default** |
-|---|---|---|---|
-| `extensions` | `array` | An array of extensions to intercept | `undefined` |
+
+#### Rendering `<head>` contents
+
+If your component, any of its children, use the `<:Head>` [component](#-head-tags), you can extract the contents:
+
+```js
+const { head } = Thing.render(data);
+```


### PR DESCRIPTION
fixes #186. Links to a currently non-existent section on `<:Head>` — PR for #171 coming shortly