### PR TITLE
tweak examples, compile in dev mode

### DIFF
--- a/content/examples/binding-media-elements/App.html
+++ b/content/examples/binding-media-elements/App.html
@@ -1,10 +1,10 @@
 <:Window on:click='seek(event)' on:mousemove='seek(event)'/>
 
-<audio bind:currentTime='t' bind:duration='d' bind:paused>
-	<source type='audio/mp3' src='{{src}}'>
+<audio bind:currentTime=t bind:duration=d bind:paused>
+	<source type='audio/mp3' src='http://deepnote.surge.sh/deepnote.mp3'>
 </audio>
 
-<p>Via <a on:click='event.stopPropagation()' href='{{url}}'>SoundCloud</a></p>
+<p>THX Deep Note</p>
 <div class='status' on:click='event.stopPropagation()'>
 	<img on:click='set({ paused: !paused })' src='{{icon}}/333333'>
 	<span class='elapsed'>{{format(t)}}</span>
@@ -12,8 +12,8 @@
 </div>
 
 <div class='progress' style='width: {{d ? 100 * t/d : 0}}%; background: {{bg}};'>
-	<p>Via <a href='{{url}}'>SoundCloud</a></p>
-	<div class='status'>
+	<p>THX Deep Note</p>
+	<div class='status' on:click='event.stopPropagation()'>
 		<img src='{{icon}}/ffffff'>
 		<span class='elapsed'>{{format(t)}}</span>
 		<span class='duration'>{{format(d)}}</span>
@@ -69,10 +69,6 @@
 
 	export default {
 		computed: {
-			src: (track, client_id) => {
-				return `https://api.soundcloud.com/tracks/${track}/stream?client_id=${client_id}`;
-			},
-
 			icon: (paused) => {
 				return `https://icon.now.sh/${paused ? 'play' : 'pause'}_circle_filled`;
 			},

--- a/content/examples/binding-media-elements/example.json
+++ b/content/examples/binding-media-elements/example.json
@@ -1,8 +1,4 @@
 {
 	"title": "Media elements",
-	"data": {
-		"track": "314855600",
-		"client_id": "3YnCkFCcm5cBfYqlXr3ufGY7k2izG1lv",
-		"url": "https://soundcloud.com/vijayandsofia/jacob-bellens-untouchable-vijay-sofia-remixmaster"
-	}
+	"data": {}
 }

--- a/content/examples/manifest.json
+++ b/content/examples/manifest.json
@@ -41,6 +41,16 @@
 	},
 
 	{
+		"name": "Transitions",
+		"examples": [
+			"transitions-fade",
+			"transitions-fly",
+			"transitions-in-out",
+			"transitions-custom"
+		]
+	},
+
+	{
 		"name": "Async data",
 		"examples": [
 			"await-block"

--- a/content/examples/parallax/App.html
+++ b/content/examples/parallax/App.html
@@ -67,11 +67,6 @@
 		position: relative;
 		z-index: 2;
 	}
-</style>
 
-<div>
-	<style>
-		/* hack to control global styles in REPL environment */
-		body { margin: 0; padding: 0; }
-	</style>
-</div>
+	:global(body) { margin: 0; padding: 0; }
+</style>

--- a/content/examples/transitions-custom/App.html
+++ b/content/examples/transitions-custom/App.html
@@ -1,0 +1,50 @@
+<input type='checkbox' bind:checked=visible> visible
+
+{{#if visible}}
+	<div class='centered' in:wheee='{duration: 8000}' out:fade>
+		<span>wheeee!!!!!</span>
+	</div>
+{{/if}}
+
+<style>
+	.centered {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		transform: translate(-50%,-50%);
+	}
+
+	span {
+		position: absolute;
+		transform: translate(-50%,-50%);
+		font-size: 4em;
+	}
+</style>
+
+<script>
+	import * as eases from 'eases-jsnext';
+	import { fade } from 'svelte-transitions';
+
+	export default {
+		transitions: {
+			wheee: (node, params) => {
+				return {
+					duration: params.duration,
+					css: t => {
+						const eased = eases.elasticOut(t);
+
+						return `
+							transform: scale(${eased}) rotate(${eased * 1080}deg);
+							color: hsl(
+								${~~(t * 360)},
+								${Math.min(100, 1000 - 1000 * t)}%,
+								${Math.min(50, 500 - 500 * t)}%
+							);`
+					}
+				};
+			},
+
+			fade
+		}
+	};
+</script>

--- a/content/examples/transitions-custom/example.json
+++ b/content/examples/transitions-custom/example.json
@@ -1,0 +1,3 @@
+{
+	"title": "Custom CSS"
+}

--- a/content/examples/transitions-fade/App.html
+++ b/content/examples/transitions-fade/App.html
@@ -1,0 +1,13 @@
+<input type='checkbox' bind:checked=visible> visible
+
+{{#if visible}}
+	<p transition:fade>fades in and out</p>
+{{/if}}
+
+<script>
+	import { fade } from 'svelte-transitions';
+
+	export default {
+		transitions: { fade }
+	};
+</script>

--- a/content/examples/transitions-fade/example.json
+++ b/content/examples/transitions-fade/example.json
@@ -1,0 +1,3 @@
+{
+	"title": "Simple fade"
+}

--- a/content/examples/transitions-fly/App.html
+++ b/content/examples/transitions-fly/App.html
@@ -1,0 +1,13 @@
+<input type='checkbox' bind:checked=visible> visible
+
+{{#if visible}}
+	<p transition:fly='{y: 200, duration: 1000}'>flies 200 pixels up, slowly</p>
+{{/if}}
+
+<script>
+	import { fly } from 'svelte-transitions';
+
+	export default {
+		transitions: { fly }
+	};
+</script>

--- a/content/examples/transitions-fly/example.json
+++ b/content/examples/transitions-fly/example.json
@@ -1,0 +1,3 @@
+{
+	"title": "Parameterised"
+}

--- a/content/examples/transitions-in-out/App.html
+++ b/content/examples/transitions-in-out/App.html
@@ -1,0 +1,13 @@
+<input type='checkbox' bind:checked=visible> visible
+
+{{#if visible}}
+	<p in:fly='{y: 50}' out:fade>flies up, fades out</p>
+{{/if}}
+
+<script>
+	import { fade, fly } from 'svelte-transitions';
+
+	export default {
+		transitions: { fade, fly }
+	};
+</script>

--- a/content/examples/transitions-in-out/example.json
+++ b/content/examples/transitions-in-out/example.json
@@ -1,0 +1,3 @@
+{
+	"title": "In and out"
+}

--- a/routes/repl/index.html
+++ b/routes/repl/index.html
@@ -460,6 +460,7 @@
 			cascade: false,
 			name: component.name,
 			filename: component.name + '.html',
+			dev: true,
 			onwarn: warning => {
 				warnings.push(warning);
 			}


### PR DESCRIPTION
Preparing a talk for this evening and found a couple of examples that ought to be tweaked.

This PR also switches the REPL to compiling in dev mode, which among other things enables CSS sourcemaps. In the longer term this should probably be a REPL option, and the CSS should be extracted out since it looks somewhat bulky when added inline with a sourcemap. But it solves the immediate problem...