### PR TITLE
fix script, allow scoped packages

### DIFF
--- a/routes/repl/_components/AppControls.html
+++ b/routes/repl/_components/AppControls.html
@@ -189,7 +189,7 @@
 					const pkg = JSON.parse(files[idx].data);
 					const deps = {};
 					bundle.imports.forEach(mod => {
-						const match = /^[^@\/]+/.exec(mod);
+						const match = /^(@[^\/]+\/)?[^@\/]+/.exec(mod);
 						deps[match[0]] = 'latest';
 					});
 					pkg.dependencies = deps;

--- a/scripts/update_template.sh
+++ b/scripts/update_template.sh
@@ -12,4 +12,4 @@ rm -rf scripts/svelte-app/src
 rm -rf scripts/svelte-app/node_modules
 
 # build svelte-app.json
-node scripts/build-svelte-app-json.js `find scripts/svelte-app/ -type f`
+node scripts/build-svelte-app-json.js `find scripts/svelte-app -type f`


### PR DESCRIPTION
The `build-svelte-app-json.js` script was failing for me locally because for some unfathomable reason I get this result on MacOS:

```bash
$ find scripts/svelte-app/ -type f
scripts/svelte-app//README.md
scripts/svelte-app//rollup.config.js
scripts/svelte-app//public/index.html
scripts/svelte-app//public/global.css
scripts/svelte-app//.gitignore
scripts/svelte-app//package.json
```

Removing the trailing slash fixes it, *hopefully* without breaking it on other platforms.