### PR TITLE
Is the "+" before getcomputedstyle a typo?

### DIFF
--- a/content/guide/07-element-directives.md
+++ b/content/guide/07-element-directives.md
@@ -307,7 +307,7 @@ Of these, `duration` is required, as is *either* `css` or `tick`. The rest are o
 	export default {
 		transitions: {
 			fade(node, { delay = 0, duration = 400 }) {
-				const o = +getComputedStyle(node).opacity;
+				const o = getComputedStyle(node).opacity;
 
 				return {
 					delay,


### PR DESCRIPTION
maybe I'm not in the know about some js syntax, but the repl seems to work without it? svelte is sweet, btw!