### PR TITLE
move immutable demo from gist to a built-in example

### DIFF
--- a/content/examples/immutable/App.html
+++ b/content/examples/immutable/App.html
@@ -1,0 +1,48 @@
+<h2>Immutable</h2>
+{#each todos as todo}
+	<label on:click="toggle(todo.id)">
+		<span>{todo.done ? "😎": "☹️"}</span>
+		<ImmutableTodo {todo}/>
+	</label>
+{/each}
+
+<h2>Mutable</h2>
+{#each todos as todo}
+	<label on:click="toggle(todo.id)">
+		<span>{todo.done ? "😎": "☹️"}</span>
+		<MutableTodo {todo}/>
+	</label>
+{/each}
+
+<script>
+	import ImmutableTodo from './ImmutableTodo.html';
+	import MutableTodo from './MutableTodo.html';
+
+	export default {
+		immutable: true,
+
+		methods: {
+			toggle(id) {
+				const { todos } = this.get();
+
+				this.set({
+					todos: todos.map(todo => {
+						if (todo.id === id) {
+							// return a new object
+							return {
+								id,
+								done: !todo.done,
+								text: todo.text
+							};
+						}
+
+						// return the same object
+						return todo;
+					})
+				});
+			}
+		},
+
+		components: { ImmutableTodo, MutableTodo }
+	}
+</script>

--- a/content/examples/immutable/ImmutableTodo.html
+++ b/content/examples/immutable/ImmutableTodo.html
@@ -1,17 +1,17 @@
 <!-- the text will flash red whenever
      the `todo` object changes -->
-		 <span ref:span>{todo.text}</span>
+<span ref:span>{todo.text}</span>
 
-		 <script>
-			 export default {
-				 // try commenting this out
-				 immutable: true,
+<script>
+	export default {
+		// try commenting this out
+		immutable: true,
 
-				 onupdate({ changed, current, previous }) {
-					 this.refs.span.style.color = 'red';
-					 setTimeout(() => {
-						 this.refs.span.style.color = 'black';
-					 }, 400);
-				 }
-			 };
-		 </script>
+		onupdate({ changed, current, previous }) {
+			this.refs.span.style.color = 'red';
+			setTimeout(() => {
+				this.refs.span.style.color = 'black';
+			}, 400);
+		}
+	};
+</script>

--- a/content/examples/immutable/ImmutableTodo.html
+++ b/content/examples/immutable/ImmutableTodo.html
@@ -1,0 +1,17 @@
+<!-- the text will flash red whenever
+     the `todo` object changes -->
+		 <span ref:span>{todo.text}</span>
+
+		 <script>
+			 export default {
+				 // try commenting this out
+				 immutable: true,
+
+				 onupdate({ changed, current, previous }) {
+					 this.refs.span.style.color = 'red';
+					 setTimeout(() => {
+						 this.refs.span.style.color = 'black';
+					 }, 400);
+				 }
+			 };
+		 </script>

--- a/content/examples/immutable/MutableTodo.html
+++ b/content/examples/immutable/MutableTodo.html
@@ -1,17 +1,17 @@
 <!-- the text will flash red whenever
      the `todo` object changes -->
-		 <span ref:span>{todo.text}</span>
+<span ref:span>{todo.text}</span>
 
-		 <script>
-			 export default {
-				 // try commenting this out
-				 immutable: true,
+<script>
+	export default {
+		// try commenting this out
+		immutable: true,
 
-				 onupdate({ changed, current, previous }) {
-					 this.refs.span.style.color = 'red';
-					 setTimeout(() => {
-						 this.refs.span.style.color = 'black';
-					 }, 400);
-				 }
-			 };
-		 </script>
+		onupdate({ changed, current, previous }) {
+			this.refs.span.style.color = 'red';
+			setTimeout(() => {
+				this.refs.span.style.color = 'black';
+			}, 400);
+		}
+	};
+</script>

--- a/content/examples/immutable/MutableTodo.html
+++ b/content/examples/immutable/MutableTodo.html
@@ -1,0 +1,17 @@
+<!-- the text will flash red whenever
+     the `todo` object changes -->
+		 <span ref:span>{todo.text}</span>
+
+		 <script>
+			 export default {
+				 // try commenting this out
+				 immutable: true,
+
+				 onupdate({ changed, current, previous }) {
+					 this.refs.span.style.color = 'red';
+					 setTimeout(() => {
+						 this.refs.span.style.color = 'black';
+					 }, 400);
+				 }
+			 };
+		 </script>

--- a/content/examples/immutable/data.json5
+++ b/content/examples/immutable/data.json5
@@ -1,0 +1,7 @@
+{
+	todos: [
+		{ id: 1, done: true, text: "wash the car" },
+		{ id: 2, done: false, text: "take the dog for a walk" },
+		{ id: 3, done: false, text: "mow the lawn" }
+	]
+}

--- a/content/examples/manifest.json
+++ b/content/examples/manifest.json
@@ -168,7 +168,7 @@
 			},
 			{
 				"slug": "immutable",
-				"title": "Immutable"
+				"title": "Immutable data"
 			}
 		]
 	}

--- a/content/examples/manifest.json
+++ b/content/examples/manifest.json
@@ -165,6 +165,10 @@
 			{
 				"slug": "hacker-news",
 				"title": "Hacker News"
+			},
+			{
+				"slug": "immutable",
+				"title": "Immutable"
 			}
 		]
 	}

--- a/content/guide/13-advanced.md
+++ b/content/guide/13-advanced.md
@@ -147,4 +147,4 @@ In the example below, `searchResults` would normally be recalculated whenever `i
 </script>
 ```
 
-[Here's a live example](repl?gist=fba9c59a0c741c635dc67f7f55b68f58) showing the effect of `immutable: true`.
+[Here's a live example](repl?demo=immutable) showing the effect of `immutable: true`.


### PR DESCRIPTION
I think it's nicer to have all of the examples in the docs be at `demo=` URLs rather than having them live in gists. I'm not entirely happy with the title and location of the example in `manifest.json`, so if you're got a better idea for that, please go for it