### PR TITLE
Update 02-template-syntax.md

### DIFF
--- a/content/guide/02-template-syntax.md
+++ b/content/guide/02-template-syntax.md
@@ -121,6 +121,8 @@ Iterate over lists of data:
 <ul>
 	{#each cats as cat}
 		<li><a target="_blank" href={cat.video}>{cat.name}</a></li>
+	{:else}
+		<li>No cats :(</li>
 	{/each}
 </ul>
 ```
@@ -144,6 +146,8 @@ Iterate over lists of data:
 	]
 }
 ```
+
+Else is triggered when the list is empty.
 
 You can access the index of the current element with *expression* as *name*, *index*:
 


### PR DESCRIPTION
Added an example for using {:else} in combination with an each block.

There is an example near the computed properties section, but it is clearer if it's shown at the introduction of each blocks.