### PR TITLE
Make store state events' properties more obvious

### DIFF
--- a/content/guide/11-state-management.md
+++ b/content/guide/11-state-management.md
@@ -28,7 +28,7 @@ Each instance of `Store` has `get`, `set`, `on` and `fire` methods that behave i
 ```js
 const { name } = store.get(); // 'world'
 
-store.on('state', ({ current }) => {
+store.on('state', ({ current, changed, previous }) => {
 	console.log(`hello ${current.name}`);
 });
 


### PR DESCRIPTION
The docs were already pretty clear on this but some people (myself included) didn't actually put two and two together that they were the same properties