### PR TITLE
Document <svelte:document>

### DIFF
--- a/content/guide/06-special-components.md
+++ b/content/guide/06-special-components.md
@@ -167,6 +167,13 @@ You can also bind to certain values — so far `innerWidth`, `outerWidth`, `inne
 ```
 
 
+### `<svelte:document>`
+
+The `<svelte:document>` tag, just like `<svelte:window>`, gives you a convenient way to declaratively add event listeners to the `document` object. Also, listeners are automatically removed when the component is destroyed. Currently useful only for listening to `mouseenter` and `mouseleave` events.
+
+Available since [2.15.0](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#2150).
+
+
 ### `<svelte:head>`
 
 If you're building an application with Svelte — particularly if you're using [Sapper](https://sapper.svelte.technology) — then it's likely you'll need to add some content to the `<head>` of your page, such as adding a `<title>` element.

--- a/content/guide/06-special-components.md
+++ b/content/guide/06-special-components.md
@@ -169,9 +169,7 @@ You can also bind to certain values — so far `innerWidth`, `outerWidth`, `inne
 
 ### `<svelte:document>`
 
-The `<svelte:document>` tag, just like `<svelte:window>`, gives you a convenient way to declaratively add event listeners to the `document` object. Also, listeners are automatically removed when the component is destroyed. Currently useful only for listening to `mouseenter` and `mouseleave` events.
-
-Available since [2.15.0](https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#2150).
+The `<svelte:document>` tag, just like `<svelte:window>`, gives you a convenient way to declaratively add event listeners to the `document` object. This is useful for listening to events that don't fire on `window`, such as `mouseenter` and `mouseleave`.
 
 
 ### `<svelte:head>`


### PR DESCRIPTION
Should address #374. Or at least be a start.

I tried adding an example, but the REPL wasn't working as expected:

```html
<svelte:document on:mouseenter='set({ entered: true })' />
	
<p>The mouse is {entered ? 'in' : 'out'}</p>

<script>
	export default {
		data() {
			return { entered: false }
		}
	}
</script>
```

Maybe that's because how the REPL is built?